### PR TITLE
refactor: remove explicit any

### DIFF
--- a/src/app/api/draft-order/route.ts
+++ b/src/app/api/draft-order/route.ts
@@ -1,22 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDraftOrder, sendInvoice } from "@/lib/shopify";
+import {
+  createDraftOrder,
+  sendInvoice,
+  DraftOrderLineItem,
+  DraftOrderPayload,
+} from "@/lib/shopify";
 
 type Body = {
   storeDomain: string;
   adminToken: string;
   customerName: string;
   customerEmail: string;
-  lineItems: Array<{ variant_id: number; quantity: number; price?: number }>;
+  lineItems: DraftOrderLineItem[];
   emailSubject?: string;
   emailBody?: string;
 };
 
 export async function POST(req: NextRequest) {
   try {
-    const { storeDomain, adminToken, customerName, customerEmail, lineItems, emailSubject, emailBody } =
-      (await req.json()) as Body;
+    const {
+      storeDomain,
+      adminToken,
+      customerName,
+      customerEmail,
+      lineItems,
+      emailSubject,
+      emailBody,
+    } = (await req.json()) as Body;
 
-    const payload = {
+    const payload: DraftOrderPayload = {
       draft_order: {
         email: customerEmail,
         note: `OrderSnap for ${customerName}`,
@@ -38,7 +50,8 @@ export async function POST(req: NextRequest) {
     );
 
     return NextResponse.json({ ok: true, draftOrderId: draft_order.id, invoiceSent: true });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 400 });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 400 });
   }
 }

--- a/src/app/api/product-search/route.ts
+++ b/src/app/api/product-search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchProducts } from "@/lib/shopify";
+import { fetchProducts, ShopifyProduct } from "@/lib/shopify";
 import Fuse from "fuse.js";
 
 type Body = {
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
     const { storeDomain, adminToken, queries } = (await req.json()) as Body;
     const products = await fetchProducts({ storeDomain, adminToken });
 
-    const fuse = new Fuse(products, {
+    const fuse = new Fuse<ShopifyProduct>(products, {
       keys: ["title"],
       threshold: 0.4, // fuzzy
       includeScore: true,
@@ -36,7 +36,8 @@ export async function POST(req: NextRequest) {
     });
 
     return NextResponse.json({ matches });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 400 });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 400 });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,8 +64,9 @@ export default function Home() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Product search failed");
       setMatches(data.matches);
-    } catch (e: any) {
-      setToast({ type: "error", msg: e.message });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Search failed";
+      setToast({ type: "error", msg });
     } finally {
       setLoading(null);
     }
@@ -121,8 +122,9 @@ export default function Home() {
       if (!res.ok) throw new Error(data.error || "Draft order creation failed");
 
       setToast({ type: "success", msg: `Draft #${data.draftOrderId} created and invoice sent.` });
-    } catch (e: any) {
-      setToast({ type: "error", msg: e.message });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Draft order failed";
+      setToast({ type: "error", msg });
     } finally {
       setLoading(null);
     }


### PR DESCRIPTION
## Summary
- add explicit Shopify types and use them across API routes
- handle unknown errors and tighten state types

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist`/`Geist Mono` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e83f7788832a88c8ed9554866dcd